### PR TITLE
Fix includes

### DIFF
--- a/src/DimensionalityReduction.jl
+++ b/src/DimensionalityReduction.jl
@@ -1,10 +1,10 @@
 module DimensionalityReduction
-	import Base.print, Base.show, Base.repl_show
-	export pca, pcaeig, pcasvd, ica, nmf, mds
+    import Base.print, Base.show, Base.repl_show
+    export pca, pcaeig, pcasvd, ica, nmf, mds
 
-	include(joinpath(julia_pkgdir(), "DimensionalityReduction", "src", "types.jl"))
-	include(joinpath(julia_pkgdir(), "DimensionalityReduction", "src", "pca.jl"))
-	include(joinpath(julia_pkgdir(), "DimensionalityReduction", "src", "nmf.jl"))
-	include(joinpath(julia_pkgdir(), "DimensionalityReduction", "src", "mds.jl"))
-    include(joinpath(julia_pkgdir(), "DimensionalityReduction", "src", "ica.jl"))
+    include("types.jl")
+    include("pca.jl")
+    include("nmf.jl")
+    include("mds.jl")
+    include("ica.jl")
 end


### PR DESCRIPTION
`julia_pkgdir()` is no longer defined as of JuliaLang/julia@c84dce7e1e0253cce91f332f048f5aaa0b0f88c2. The spacing changes are tabs -> spaces, since the rest of the package seems to use spaces.
