### PR TITLE
Fixed warnings for function max.

### DIFF
--- a/src/nmf.jl
+++ b/src/nmf.jl
@@ -24,7 +24,7 @@ function nmf(X::Matrix,
         H .*= updateH
         updateW = (X * H') ./ (W * (H * H') + epsilon)
         W .*= updateW
-        max_update = max(max(updateH), max(updateW))
+        max_update = max(maximum(updateH), maximum(updateW))
         if abs(1.0 - max_update) < tolerance
             break
         end


### PR DESCRIPTION
Hello,

I fixed warnings about the deprecated function max (used in NMF method). We should use maximum instead. Does the fix seem good to you ?

Bests.
