### PR TITLE
add a warning to deprecate this package (in favor of MultivariateStats).

### DIFF
--- a/src/DimensionalityReduction.jl
+++ b/src/DimensionalityReduction.jl
@@ -1,4 +1,6 @@
 module DimensionalityReduction
+	warn("The DimensionalityReduction package is deprecated. It is superseded by a new package MultivariateStats.")
+
     export pca, pcaeig, pcasvd
     export ica, nmf, mds, tsne
 


### PR DESCRIPTION
The package MultivariateStats provides better support of dimensionality reduction tasks.

See discussion in https://groups.google.com/forum/#!topic/julia-users/4ejftXei3dc.

With this PR, when this package is imported, a warning would be raised to explain the situation.

cc: @johnmyleswhite @IainNZ
